### PR TITLE
Upgrade Metrics Server to v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,38 @@ This module manages several add-ons that might be needed in an EKS cluster. It c
 - Cluster autoscaling
 - AWS Load Balancer Controller
 
-Ideally this module should not be necessary, and all these add-ons could be installed from the `simple-eks` module itself. But, the Terraform provider for Kubernetes has some limitations that prevented us from doing so. In short, the Kubernetes provider cannot be initialized with credentials obtained in the same `terraform apply` execution where the cluster is created. (See the warning box in https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#stacking-with-managed-kubernetes-cluster-resources for more details).
+Ideally this module should not be necessary, and all these add-ons could be installed from the `simple-eks` module itself. But, the Terraform provider for Kubernetes has some limitations that prevented us from doing so. In short, the Kubernetes provider cannot be initialized with credentials obtained in the same `terraform apply` execution where the cluster is created. (See the warning box in <https://registry.terraform.io/providers/hashicorp/kubernetes/latest/> docs#stacking-with-managed-kubernetes-cluster-resources for more details).
+
+## Development
+
+### Update Metrics Server
+
+When updating to a newer version of the metrics server, the container arguments need to be changed as shown below.
+
+From:
+
+```yaml
+- args:
+    - --cert-dir=/tmp
+    - --secure-port=443
+    - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+    - --kubelet-use-node-status-port
+    - --metric-resolution=15s
+```
+
+To:
+
+```yaml
+- args:
+    - --cert-dir=/tmp
+    - --secure-port=443
+    - --kubelet-preferred-address-types=InternalIP
+    - --kubelet-use-node-status-port
+    - --metric-resolution=15s
+    - --kubelet-insecure-tls
+```
+
+Also, add `hostNetwork: ${host_network}` to the template spec.
 
 ## References
 
@@ -19,4 +50,4 @@ Ideally this module should not be necessary, and all these add-ons could be inst
 
 ### Calico
 
-- https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network
+- <https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network>

--- a/cluster-autoscaler.tf
+++ b/cluster-autoscaler.tf
@@ -4,9 +4,13 @@ resource "null_resource" "cluster_autoscaler" {
   triggers = {
     always_run = uuid()
     yaml = replace(
-      file("${path.module}/data/cluster-autoscaler-autodiscover.yaml"),
-      "<YOUR CLUSTER NAME>",
-      var.cluster_name
+        replace(
+          file("${path.module}/data/cluster-autoscaler-autodiscover.yaml"),
+          "<YOUR CLUSTER NAME>",
+          var.cluster_name
+      ),
+      "<YOUR AWS REGION>",
+      var.region
     )
   }
 

--- a/data/cluster-autoscaler-autodiscover.yaml
+++ b/data/cluster-autoscaler-autodiscover.yaml
@@ -74,10 +74,11 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["create","list","watch"]
+    verbs: ["create", "list", "watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
+    resourceNames:
+      ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
     verbs: ["delete", "get", "update", "watch"]
 
 ---
@@ -140,7 +141,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: eu.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v1.16.6
+        - image: eu.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v1.20.0
           name: cluster-autoscaler
           resources:
             limits:
@@ -149,6 +150,9 @@ spec:
             requests:
               cpu: 100m
               memory: 300Mi
+          env:
+            - name: AWS_REGION
+              value: <YOUR AWS REGION>
           command:
             - ./cluster-autoscaler
             - --v=4
@@ -158,7 +162,7 @@ spec:
             - --expander=least-waste
             - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/<YOUR CLUSTER NAME>
             - --balance-similar-node-groups
-            - --skip-nodes-with-system-pods=false            
+            - --skip-nodes-with-system-pods=false
           volumeMounts:
             - name: ssl-certs
               mountPath: /etc/ssl/certs/ca-certificates.crt

--- a/data/metrics-server.tpl.yaml
+++ b/data/metrics-server.tpl.yaml
@@ -1,33 +1,56 @@
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+apiVersion: v1
+kind: ServiceAccount
 metadata:
-  name: system:aggregated-metrics-reader
   labels:
-    rbac.authorization.k8s.io/aggregate-to-view: "true"
-    rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
-rules:
-- apiGroups: ["metrics.k8s.io"]
-  resources: ["pods", "nodes"]
-  verbs: ["get", "list", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: metrics-server:system:auth-delegator
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:auth-delegator
-subjects:
-- kind: ServiceAccount
+    k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: system:aggregated-metrics-reader
+rules:
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes
+      - nodes/stats
+      - namespaces
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  labels:
+    k8s-app: metrics-server
   name: metrics-server-auth-reader
   namespace: kube-system
 roleRef:
@@ -35,120 +58,131 @@ roleRef:
   kind: Role
   name: extension-apiserver-authentication-reader
 subjects:
-- kind: ServiceAccount
-  name: metrics-server
-  namespace: kube-system
----
-apiVersion: apiregistration.k8s.io/v1beta1
-kind: APIService
-metadata:
-  name: v1beta1.metrics.k8s.io
-spec:
-  service:
+  - kind: ServiceAccount
     name: metrics-server
     namespace: kube-system
-  group: metrics.k8s.io
-  version: v1beta1
-  insecureSkipTLSVerify: true
-  groupPriorityMinimum: 100
-  versionPriority: 100
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: metrics-server
-  namespace: kube-system
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: metrics-server
-  namespace: kube-system
-  labels:
-    k8s-app: metrics-server
-spec:
-  selector:
-    matchLabels:
-      k8s-app: metrics-server
-  template:
-    metadata:
-      name: metrics-server
-      labels:
-        k8s-app: metrics-server
-    spec:
-      serviceAccountName: metrics-server
-      volumes:
-      # mount in tmp so we can safely use from-scratch images and/or read-only containers
-      - name: tmp-dir
-        emptyDir: {}
-      containers:
-      - name: metrics-server
-        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
-        imagePullPolicy: IfNotPresent
-        args:
-          - --cert-dir=/tmp
-          - --secure-port=4443
-          - --kubelet-insecure-tls=true
-          - --kubelet-preferred-address-types=InternalIP
-        ports:
-        - name: main-port
-          containerPort: 4443
-          protocol: TCP
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 1000
-        volumeMounts:
-        - name: tmp-dir
-          mountPath: /tmp
-      nodeSelector:
-        kubernetes.io/os: linux
-        kubernetes.io/arch: "amd64"
-      hostNetwork: ${host_network}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: metrics-server
-  namespace: kube-system
-  labels:
-    kubernetes.io/name: "Metrics-server"
-    kubernetes.io/cluster-service: "true"
-spec:
-  selector:
-    k8s-app: metrics-server
-  ports:
-  - port: 443
-    protocol: TCP
-    targetPort: main-port
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: system:metrics-server
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  - nodes/stats
-  - namespaces
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
   name: system:metrics-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: system:metrics-server
 subjects:
-- kind: ServiceAccount
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
+spec:
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+  selector:
+    k8s-app: metrics-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        k8s-app: metrics-server
+    spec:
+      containers:
+        - args:
+            - --cert-dir=/tmp
+            - --secure-port=4443
+            - --kubelet-preferred-address-types=InternalIP
+            - --kubelet-use-node-status-port
+            - --kubelet-insecure-tls
+          image: k8s.gcr.io/metrics-server/metrics-server:v0.4.3
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: https
+              scheme: HTTPS
+            periodSeconds: 10
+          name: metrics-server
+          ports:
+            - containerPort: 4443
+              name: https
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: https
+              scheme: HTTPS
+            periodSeconds: 10
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp-dir
+      hostNetwork: ${host_network}
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      serviceAccountName: metrics-server
+      volumes:
+        - emptyDir: {}
+          name: tmp-dir
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: v1beta1.metrics.k8s.io
+spec:
+  group: metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: metrics-server
+    namespace: kube-system
+  version: v1beta1
+  versionPriority: 100

--- a/data/metrics-server.tpl.yaml
+++ b/data/metrics-server.tpl.yaml
@@ -130,11 +130,12 @@ spec:
       containers:
         - args:
             - --cert-dir=/tmp
-            - --secure-port=4443
+            - --secure-port=443
             - --kubelet-preferred-address-types=InternalIP
             - --kubelet-use-node-status-port
+            - --metric-resolution=15s
             - --kubelet-insecure-tls
-          image: k8s.gcr.io/metrics-server/metrics-server:v0.4.3
+          image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -145,7 +146,7 @@ spec:
             periodSeconds: 10
           name: metrics-server
           ports:
-            - containerPort: 4443
+            - containerPort: 443
               name: https
               protocol: TCP
           readinessProbe:
@@ -154,7 +155,12 @@ spec:
               path: /readyz
               port: https
               scheme: HTTPS
+            initialDelaySeconds: 20
             periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true


### PR DESCRIPTION
- Upgrade cluster-autoscaler to 1.20.0 and add AWS_REGION to fetch prices of the region where the cluster autoscaler is deployed;
- Upgrade metrics-server to 0.4.3.
