### PR TITLE
Add missing permission to the load balancer controller's policy

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -238,6 +238,26 @@ resource "aws_iam_role_policy" "aws_load_balancer_controller" {
         }
       },
       {
+        "Effect": "Allow",
+        "Action": ["elasticloadbalancing:AddTags"],
+        "Resource": [
+          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+        ],
+        "Condition": {
+          "StringEquals": {
+            "elasticloadbalancing:CreateAction": [
+              "CreateTargetGroup",
+              "CreateLoadBalancer"
+            ]
+          },
+          "Null": {
+            "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+          }
+        }
+      },
+      {
         "Effect" : "Allow",
         "Action" : [
           "elasticloadbalancing:RegisterTargets",


### PR DESCRIPTION
Update IAM policy for the load balancer controller, following AWS' recommendations [here](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/install/iam_policy.json).