### PR TITLE
Add flag to control WAF association

### DIFF
--- a/load-balancer-controller.tf
+++ b/load-balancer-controller.tf
@@ -40,6 +40,15 @@ resource "helm_release" "load_balancer_controller" {
     }
   }
 
+  dynamic "set" {
+    for_each = var.load_balancer_controller.enable_wafv2 != null ? [1] : []
+
+    content {
+      name  = "enableWafv2"
+      value = var.load_balancer_controller.enable_wafv2
+    }
+  }
+
   depends_on = [
     null_resource.load_balancer_target_group_bindings
   ]

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,7 @@ variable "load_balancer_controller" {
     enabled       = bool
     chart_version = optional(string)
     image_tag     = optional(string)
+    enable_wafv2  = optional(bool)
   })
   default = null
 }


### PR DESCRIPTION
The AWS load balancer controller can manage WAF associations with the load balancer. Sometimes this is not desirable (e.g., when the association is maintained in some other way). As described [here](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.6/guide/ingress/annotations/#addons), it is possible to control this behavior. This PR add support to specify whether the controller should manage WAF associations or not.